### PR TITLE
Fix the css issue with the answer after the answer button is pressed

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -92,6 +92,7 @@
 
 .answer-disabled {
   margin-bottom: 5px;
+  width: 95%;
   cursor: auto;
 }
 


### PR DESCRIPTION
Amended the width on the answer-disabled CSS to match the answer CSS, fixing the issue that the selected option would get larger after the answer button was pressed.